### PR TITLE
fix(kiteworks): createDir with 409 + ERR_ENTITY_EXISTS is not an error

### DIFF
--- a/backend/kiteworks/kiteworks.go
+++ b/backend/kiteworks/kiteworks.go
@@ -948,6 +948,10 @@ func (f *Fs) createDir(ctx context.Context, pathID, leaf string) (newDir *api.Fi
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
+		msg := err.Error()
+		if strings.HasPrefix(msg, "HTTP error 409 (409 Conflict) returned body") && strings.Contains(msg, "ERR_ENTITY_EXISTS") {
+			return newDir, nil
+		}
 		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
